### PR TITLE
fix: no longer special case 3.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 *NOTE*: This file is auto-generated, so please don't edit manually. See the [CONTRIBUTING guide](CONTRIBUTING.md) to see how to update it.
 
-*Generated with Scala 3.1.3-RC2*
+*Generated with Scala 3.2.0-RC1-bin-20220412-1503044-NIGHTLY*
 
 ## E000 EmptyCatchOrFinallyBlockID
 **NOTE:** This error is no longer emitted by the compiler.

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -4,7 +4,7 @@ source bin/colors.sh
 
 TARGET_FILES=$(ls examples/*.scala)
 OUTPUT=README.md
-SCALA_VERSION=$(cs complete-dep org.scala-lang:scala3-compiler_3: | grep 3.1.3 | tail -1)
+SCALA_VERSION=$(cs complete-dep org.scala-lang:scala3-compiler_3: | grep NIGHTLY | tail -1)
 
 rm -f -- $OUTPUT
 

--- a/bin/checker.sh
+++ b/bin/checker.sh
@@ -2,11 +2,7 @@
 
 source bin/colors.sh
 
-# Nightlies were published wrong so there are some 3.2.0 that are incorrect for so for now
-# we can't do the below, but after the next release we should be able to so for now we look
-# only for the 3.1.3 ones
-#SCALA_VERSION=$(cs complete-dep org.scala-lang:scala3-compiler_3: | grep NIGHTLY | tail -1)
-SCALA_VERSION=$(cs complete-dep org.scala-lang:scala3-compiler_3: | grep 3.1.3 | tail -1)
+SCALA_VERSION=$(cs complete-dep org.scala-lang:scala3-compiler_3: | grep NIGHTLY | tail -1)
 TARGET_FILES=$(ls examples/*.scala)
 COMMAND="$1"
 ERROR_MESSAGE_ID="$2"


### PR DESCRIPTION
Now that Dotty is back on track publishing the correctly nightlies we
can switch the logic that grabs the scala version to go back to just
grepping all the nightlies and getting the latest.
