### PR TITLE
Add in 061_TopLevelCantBeImplicit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,6 @@ hasn't been figure out, or is it because the code that references the specific
   - [ ] 047 CyclicReferenceInvolvingImplicitID - See notes in the file
   - [ ] 054 ParameterizedTypeLacksArgumentsID
   - [ ] 059 DoesNotConformToSelfTypeCantBeInstantiated
-  - [ ] 061 TopLevelCantBeImplicitID
 
 ## Getting Started
 

--- a/examples/061_TopLevelCantBeImplicitID.scala
+++ b/examples/061_TopLevelCantBeImplicitID.scala
@@ -1,6 +1,9 @@
-// I can't seem to reproduce this one. I see in `Checking.scala` that is should
-// be it if sym.owner.is(Package), but when playing around that doesn't seem to
-// ever be true
-// INCOMPLETE
+// LEGACY In the past top level implicit were not allowed. This is however no longer the case as of https://github.com/lampepfl/dotty/pull/5754
+// START
 @main def TopLevelCantBeImplicitID = ()
 
+import scala.language.implicitConversions
+case class C(str: String)
+implicit def toC(x: String): C = C(x)
+implicit val defaultC: C = C("default")
+// END

--- a/examples/061_TopLevelCantBeImplicitID.scala
+++ b/examples/061_TopLevelCantBeImplicitID.scala
@@ -1,9 +1,5 @@
 // LEGACY In the past top level implicit were not allowed. This is however no longer the case as of https://github.com/lampepfl/dotty/pull/5754
 // START
 @main def TopLevelCantBeImplicitID = ()
-
-import scala.language.implicitConversions
-case class C(str: String)
-implicit def toC(x: String): C = C(x)
-implicit val defaultC: C = C("default")
+implicit val foo: String = "foo"
 // END


### PR DESCRIPTION
Adding `// LEGACY` to 061.
It seems like TopLevelCantBeImplicit is no longer the case thanks to https://github.com/lampepfl/dotty/pull/5754

This is actually confirmed in https://github.com/lampepfl/dotty/blob/93fc41fcb624df73cc12d52b79d518a30a778a7c/tests/run/toplevel-implicits/a.b.scala#L19-L21

---

I'm planning to refactor the dotty repo to delete the `TopLevelCantBeImplicit` error message-id, and the check logic (as it's a dead code now). In that case, should we keep `TopLevelCantBeImplicit` in `dotty-error-index` repo?

---

Thank you very much for kicking off https://contributors.scala-lang.org/t/revisiting-dotty-diagnostics-for-tooling/5649/15 @ckipp01 ! This is definitely a good way to improve the devtools experience, the user experience of Scala (especially for newcomers).