### PR TITLE
refactor(ci): only generate on main and cron run

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,20 @@
+name: check
+
+on:
+  pull_request:
+
+jobs:
+  error-check:
+    name: Check errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: coursier/cache-action@v6
+      - uses: coursier/setup-action@v1.2.0-M3
+        with:
+          jvm: temurin:1.17
+          apps: ""
+
+      - name: Check all errors
+        run: make check

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,10 +1,9 @@
-name: CI
+name: generate
 
 on:
   push:
     branches:
       - main
-  pull_request:
   schedule:
     - cron: 0 9 * * *
 


### PR DESCRIPTION
When someone creates a pr it won't work to regenerate the index on their
branch since it won't be able to commit it back. So this splits CI into
two different jobs, one is just a check that will always run during prs
and the other runs during the merge and during the nightly cron to test,
build, and then commit the changes.
