### PR TITLE
Add 059 DoesNotConformToSelfTypeCantBeInstantiated

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,6 @@ hasn't been figure out, or is it because the code that references the specific
   - [ ] 046 CyclicReferenceInvolvingID - See notes in the file
   - [ ] 047 CyclicReferenceInvolvingImplicitID - See notes in the file
   - [ ] 054 ParameterizedTypeLacksArgumentsID
-  - [ ] 059 DoesNotConformToSelfTypeCantBeInstantiated
 
 ## Getting Started
 

--- a/checkfiles/059_DoesNotConformToSelfTypeCantBeInstantiated.check
+++ b/checkfiles/059_DoesNotConformToSelfTypeCantBeInstantiated.check
@@ -1,0 +1,21 @@
+-- [E058] Type Mismatch Error: examples/059_DoesNotConformToSelfTypeCantBeInstantiated.scala:7:8 
+7 |  class Foo extends Bar
+  |        ^
+  |illegal inheritance: self type Foo of class Foo does not conform to self type Baz
+  |of parent trait Bar
+  |-----------------------------------------------------------------------------
+  | Explanation (enabled by `-explain`)
+  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  | I tried to show that
+  |   Foo
+  | conforms to
+  |   Baz
+  | but the comparison trace ended with `false`:
+  |
+  |   ==> Foo  <:  Baz
+  |   <== Foo  <:  Baz = false
+  |
+  | The tests were made under the empty constraint
+   -----------------------------------------------------------------------------
+1 error found
+Error: Errors encountered during compilation

--- a/examples/059_DoesNotConformToSelfTypeCantBeInstantiated.scala
+++ b/examples/059_DoesNotConformToSelfTypeCantBeInstantiated.scala
@@ -1,2 +1,8 @@
-// INCOMPLETE
-@main def DoesNotConformToSelfTypeCantBeInstantiated = ()
+// START
+@main def DoesNotConformToSelfTypeCantBeInstantiated =
+  class Baz
+  trait Bar {
+    self: Baz =>
+  }
+  class Foo extends Bar
+// END


### PR DESCRIPTION
This PR adds an example for 059.
Error 059 occurs when the class doesn't conform the self type constraint, as tested in https://github.com/lampepfl/dotty/blob/2042a08a78071860d3283a2e92812e65bc7b4efb/tests/neg/selfInheritance.scala