### PR TITLE
Add 054 ParameterizedTypeLacksArguments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,6 @@ hasn't been figure out, or is it because the code that references the specific
   - [ ] 038 OverridesNothingButNameExistsID - See notes in the file
   - [ ] 046 CyclicReferenceInvolvingID - See notes in the file
   - [ ] 047 CyclicReferenceInvolvingImplicitID - See notes in the file
-  - [ ] 054 ParameterizedTypeLacksArgumentsID
   - [ ] 059 DoesNotConformToSelfTypeCantBeInstantiated
 
 ## Getting Started

--- a/checkfiles/054_ParameterizedTypeLacksArgumentsID.check
+++ b/checkfiles/054_ParameterizedTypeLacksArgumentsID.check
@@ -1,0 +1,12 @@
+-- [E054] Type Error: examples/054_ParameterizedTypeLacksArgumentsID.scala:4:16 
+4 |  val foo = new Foo {}
+  |                ^^^
+  |                Parameterized trait Foo lacks argument list
+  |-----------------------------------------------------------------------------
+  | Explanation (enabled by `-explain`)
+  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  | The trait Foo is declared with non-implicit parameters, you may not leave
+  | out the parameter list when extending it.
+   -----------------------------------------------------------------------------
+1 error found
+Error: Errors encountered during compilation

--- a/examples/054_ParameterizedTypeLacksArgumentsID.scala
+++ b/examples/054_ParameterizedTypeLacksArgumentsID.scala
@@ -1,2 +1,5 @@
-//INCOMPLETE
-@main def ParameterizedTypeLacksArgumentsID = ()
+// START
+@main def ParameterizedTypeLacksArgumentsID =
+  trait Foo(x: Int)
+  val foo = new Foo {}
+// END


### PR DESCRIPTION
The error occurs when the `trait Foo` is parameterized, but it doesn't have arguments.

```scala
trait Foo(x: Int)
val foo = new Foo {}
```

---

BTW, the following code gives me: `missing argument for parameter x of constructor Foo in trait Foo: (x: Int)`


```scala
trait Foo(x: Int)
val foo = new Foo
```